### PR TITLE
Running with non-root user

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,8 +7,8 @@ RUN sh docker-build.sh && rm docker-build.sh
 EXPOSE 1883 8083 8883 18083
 VOLUME /etc/emqttd/config /etc/emqttd/plugins
 
+WORKDIR /opt/emqttd
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["start-daemon"]
+CMD ["emqttd", "foreground"]

--- a/src/docker-build.sh
+++ b/src/docker-build.sh
@@ -1,16 +1,43 @@
 #!/bin/bash
 
+# set user and group first
+groupadd -r emqttd && useradd -rm -g emqttd emqttd
+
 # common variables
-BUILD_DEPS='wget unzip'
+BUILD_DEPS='wget unzip ca-certificates'
 RUNTIME_DEPS='openssl'
-EMQTTD_URL=http://emqtt.io/downloads/latest/debian
-ARCHIVE=/opt/temp.zip
 
 # install system dependencies
 apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS $RUNTIME_DEPS
 
-# install broker and add it to PATH
-wget -O $ARCHIVE "$EMQTTD_URL"; unzip $ARCHIVE -d /opt; rm $ARCHIVE
+# install gosu
+GOSU_VERSION=1.7
+GOSU_URL="https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)"
+
+set -x \
+    && wget -O /usr/local/bin/gosu "$GOSU_URL" \
+    && wget -O /usr/local/bin/gosu.asc "$GOSU_URL.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true
+
+# download and unpack broker
+EMQTTD_VERSION="latest"
+EMQTTD_URL=http://emqtt.io/downloads/$EMQTTD_VERSION/debian
+EMQTTD_ZIP=/opt/emqttd.zip
+
+set -ex \
+    && wget -O $EMQTTD_ZIP "$EMQTTD_URL" \
+    && unzip $EMQTTD_ZIP -d /opt \
+    && rm $EMQTTD_ZIP
+
+# add broker to PATH by symlinking
+EMQTTD_BIN=/opt/emqttd/bin
+ln -s $EMQTTD_BIN/emqttd /usr/local/bin/emqttd
+ln -s $EMQTTD_BIN/emqttd_ctl /usr/local/bin/emqttd_ctl
 
 # cleanup
 apt-get purge -y --auto-remove $BUILD_DEPS

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 EMQTTD_DIR=/opt/emqttd
 
-copy_config() {
+_copy_config() {
     CONFIG_VOLUME=/etc/emqttd/config
 
     if [ "$(ls -A $CONFIG_VOLUME)" ]; then
@@ -12,9 +12,9 @@ copy_config() {
     fi
 }
 
-load_plugins() {
+_load_plugins() {
     PLUGINS_LIST=$EMQTTD_DIR/etc/plugins.list
-    if [[ -f $PLUGINS_LIST ]]; then
+    if [ -f $PLUGINS_LIST ]; then
         # wait for daemon to start
         sleep 5
 
@@ -25,18 +25,17 @@ load_plugins() {
 
         while IFS= read -r plugin; do
             echo "Loading $plugin..."
-            $EMQTTD_DIR/bin/emqttd_ctl plugins load $plugin &
+            emqttd_ctl plugins load $plugin &
         done < $PLUGINS_LIST
     fi
 }
 
-case "$1" in
-    "start-daemon")
-        copy_config
-        load_plugins &
-        $EMQTTD_DIR/bin/emqttd-2.0 foreground
-        ;;
-    *)
-        # run any user-provided command
-        exec "$@"
-esac
+if [ "$1" = 'emqttd' -a "$(id -u)" = '0' ]; then
+    _copy_config
+    _load_plugins &
+
+    chown -R emqttd .
+    exec gosu emqttd "$0" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Fixes:
- broker is started with a non-root user using gosu utility

Features:
- improved command execution, e.g. "docker exec -it <container_name> emqttd ping"